### PR TITLE
Fix settings menu scrolling

### DIFF
--- a/src/features/Settings.cpp
+++ b/src/features/Settings.cpp
@@ -21,9 +21,16 @@ void Settings::update() {
     return;
   }
 
+  int scroll = input.getScrollAmount();
   int pot = analogRead(39);
   if (mode == MENU) {
-    selection = map(pot, 0, 4095, 0, 2);
+    if (scroll != 0) {
+      int prev = selection;
+      selection += scroll;
+      if (selection < 0) selection = 0;
+      if (selection > 2) selection = 2;
+      if (selection != prev && !muted) buzzer.click();
+    }
     if (input.singleClicked()) {
       if (selection == 0) {
         muted = !muted;
@@ -46,7 +53,11 @@ void Settings::update() {
       if (!muted) buzzer.click();
     }
   } else if (mode == INSTRUCTIONS) {
-    scrollLine = map(pot, 0, 4095, 0, 4);
+    if (scroll != 0) {
+      scrollLine += scroll;
+      if (scrollLine < 0) scrollLine = 0;
+      if (scrollLine > 4) scrollLine = 4;
+    }
   }
 }
 
@@ -83,11 +94,11 @@ void Settings::drawInstructions(DisplayManager& display) {
   const char* lines[] = {
     "Scroll to select",
     "Click to enter mode",
-    "Double click to exit",
+    "Hold button to exit",
     "Set timer with pot",
     "Breathe with rhythm"
   };
 
   display.drawText(lines[scrollLine], 0, 30);
-  display.drawText("Double-click to exit", 0, 55);
+  display.drawText("Hold to exit", 0, 55);
 }

--- a/src/hardware/InputManager.cpp
+++ b/src/hardware/InputManager.cpp
@@ -23,16 +23,32 @@ void InputManager::update() {
 
   singleClickFlag = false;
   doubleClickFlag = false;
+  longPressFlag = false;
 
-  if (!lastButtonState && currentState) { // Rising edge: button just pressed
-    unsigned long now = millis();
-    if (now - lastClickTime < 400) {
-      doubleClickFlag = true;
-      lastClickTime = 0; // reset
+  unsigned long now = millis();
+
+  if (currentState && !lastButtonState) {
+    pressStartTime = now; // button pressed
+  }
+
+  if (!currentState && lastButtonState) { // released
+    unsigned long duration = now - pressStartTime;
+    if (duration >= longPressDuration) {
+      longPressFlag = true;
+      lastClickTime = 0;
     } else {
-      singleClickFlag = true;
-      lastClickTime = now;
+      if (now - lastClickTime < 400) {
+        doubleClickFlag = true;
+        lastClickTime = 0;
+      } else {
+        singleClickFlag = true;
+        lastClickTime = now;
+      }
     }
+    pressStartTime = 0;
+  } else if (currentState && (now - pressStartTime >= longPressDuration)) {
+    longPressFlag = true;
+    lastClickTime = 0;
   }
 
   lastButtonState = currentState;
@@ -52,4 +68,8 @@ bool InputManager::singleClicked() {
 
 bool InputManager::doubleClicked() {
   return doubleClickFlag;
+}
+
+bool InputManager::longPressed() {
+  return longPressFlag;
 }

--- a/src/hardware/InputManager.h
+++ b/src/hardware/InputManager.h
@@ -14,6 +14,7 @@ public:
   bool isButtonPressed();      // Instantaneous read of the button state
   bool singleClicked();        // True once on press edge
   bool doubleClicked();        // True if double click detected
+  bool longPressed();          // True if button held
 
 private:
   const int potPin = 39;
@@ -26,7 +27,10 @@ private:
   bool lastButtonState = true;
   bool singleClickFlag = false;
   bool doubleClickFlag = false;
+  bool longPressFlag = false;
   unsigned long lastClickTime = 0;
+  unsigned long pressStartTime = 0;
+  const unsigned long longPressDuration = 1500; // ms
 };
 
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -45,7 +45,7 @@ void loop() {
     display.update();
 
     //  Allow returning to menu
-    if (input.doubleClicked()) {
+    if (input.longPressed()) {
       activeFeature = nullptr;
       buzzer.click();
     }


### PR DESCRIPTION
## Summary
- keep menu behavior consistent and incremental
- change exit gesture to long-press
- update help text for long press exit

## Testing
- `platformio --version` *(fails: command not found)*
