### PR TITLE
Add tomato sprite to all screens

### DIFF
--- a/include/globals.h
+++ b/include/globals.h
@@ -4,10 +4,12 @@
 #include "hardware/DisplayManager.h"
 #include "hardware/InputManager.h"
 #include "hardware/Buzzer.h"
+#include "ui/TomatoSprite.h"
 
 // Declare global instances used across features
 extern DisplayManager display;
 extern InputManager input;
 extern Buzzer buzzer;
+extern TomatoSprite sprite;
 
 #endif

--- a/src/features/Breathing.cpp
+++ b/src/features/Breathing.cpp
@@ -1,9 +1,6 @@
 #include "features/Breathing.h"
-#include "hardware/InputManager.h"
-#include "hardware/Buzzer.h"
+#include "globals.h"
 
-extern InputManager input;
-extern Buzzer buzzer;
 
 Breathing::Breathing() {
   reset();
@@ -76,6 +73,14 @@ void Breathing::update() {
 }
 
 void Breathing::draw(DisplayManager& display) {
+  if (state == COMPLETE) {
+    sprite.drawCheer(display, 90, 0);
+  } else if (state == RUNNING) {
+    sprite.drawWink(display, 90, 0);
+  } else {
+    sprite.drawIdle(display, 90, 0);
+  }
+
   switch (state) {
     case SELECT_METHOD:
       drawMenu(display);

--- a/src/features/Garden.cpp
+++ b/src/features/Garden.cpp
@@ -1,11 +1,8 @@
 // Garden.cpp - Tracks tomato growth based on completed focus sessions
 
 #include "features/Garden.h"
-#include "hardware/InputManager.h"
-#include "ui/TomatoSprite.h"
+#include "globals.h"
 
-extern InputManager input;
-extern TomatoSprite sprite;
 
 Garden::Garden() {
   stage = 0;
@@ -37,6 +34,12 @@ void Garden::update() {
 
 void Garden::draw(DisplayManager& display) {
   display.drawText("My Garden", 30, 0);
+
+  if (stage >= 4) {
+    sprite.drawCheer(display, 90, 0);
+  } else {
+    sprite.drawIdle(display, 90, 0);
+  }
 
   // moving clouds
   display.drawText("~~~", cloud1X, 10);

--- a/src/features/Pomodoro.cpp
+++ b/src/features/Pomodoro.cpp
@@ -1,12 +1,7 @@
 #include "features/Pomodoro.h"
-#include "hardware/InputManager.h"
-#include "hardware/Buzzer.h"
-#include "ui/TomatoSprite.h"
+#include "globals.h"
 #include "ui/Menu.h"
 
-extern InputManager input;
-extern Buzzer buzzer;
-extern TomatoSprite sprite;
 extern Menu menu;
 
 Pomodoro::Pomodoro() {
@@ -130,7 +125,22 @@ void Pomodoro::update() {
 
 void Pomodoro::draw(DisplayManager& display) {
   char buf[16];
-  //sprite.drawIdle(display, 90, 0);
+
+  // Show companion sprite in top-right corner
+  switch (state) {
+    case FINISHED:
+      sprite.drawCheer(display, 90, 0);
+      break;
+    case PAUSED:
+      sprite.drawSad(display, 90, 0);
+      break;
+    case RUNNING_BREAK:
+      sprite.drawWink(display, 90, 0);
+      break;
+    default:
+      sprite.drawIdle(display, 90, 0);
+      break;
+  }
 
   switch (state) {
     case SELECTING_WORK:

--- a/src/features/Pong.cpp
+++ b/src/features/Pong.cpp
@@ -1,11 +1,6 @@
 #include "features/Pong.h"
-#include "hardware/InputManager.h"
-#include "hardware/Buzzer.h"
-#include "ui/TomatoSprite.h"
+#include "globals.h"
 
-extern InputManager input;
-extern Buzzer buzzer;
-extern TomatoSprite sprite;
 
 Pong::Pong() {
   resetGame();

--- a/src/features/PowerNap.cpp
+++ b/src/features/PowerNap.cpp
@@ -1,11 +1,8 @@
 // PowerNap.cpp - Nap timer feature logic
 
 #include "features/PowerNap.h"
-#include "hardware/InputManager.h"
-#include "hardware/Buzzer.h"
+#include "globals.h"
 
-extern InputManager input;
-extern Buzzer buzzer;
 
 PowerNap::PowerNap() {
   state = SELECTING;
@@ -37,6 +34,14 @@ void PowerNap::update() {
 
 void PowerNap::draw(DisplayManager& display) {
   display.drawText("Power Nap", 30, 0);
+
+  if (state == DONE) {
+    sprite.drawCheer(display, 90, 0);
+  } else if (state == NAPPING) {
+    sprite.drawWink(display, 90, 0);
+  } else {
+    sprite.drawIdle(display, 90, 0);
+  }
 
   if (state == SELECTING) {
     display.drawText("Set: ", 10, 20);

--- a/src/features/Settings.cpp
+++ b/src/features/Settings.cpp
@@ -1,13 +1,9 @@
 // Settings.cpp - Menu and configuration UI for HappyTomato
 
 #include "features/Settings.h"
-#include "hardware/InputManager.h"
-#include "hardware/Buzzer.h"
+#include "globals.h"
 #include "hardware/DisplayManager.h"
 
-extern DisplayManager display;
-extern InputManager input;
-extern Buzzer buzzer;
 
 Settings::Settings() {
   mode = MENU;
@@ -71,6 +67,12 @@ void Settings::update() {
 }
 
 void Settings::draw(DisplayManager& display) {
+  if (mode == INSTRUCTIONS) {
+    sprite.drawWink(display, 90, 0);
+  } else {
+    sprite.drawIdle(display, 90, 0);
+  }
+
   if (mode == MENU) {
     drawMenu(display);
   } else if (mode == BRIGHTNESS) {

--- a/src/features/Stopwatch.cpp
+++ b/src/features/Stopwatch.cpp
@@ -1,13 +1,9 @@
 // Stopwatch.cpp - Stopwatch logic for HappyTomato
 
 #include "features/Stopwatch.h"
-#include "hardware/InputManager.h"
-#include "hardware/Buzzer.h"
+#include "globals.h"
 #include "hardware/DisplayManager.h"
 
-extern InputManager input;
-extern Buzzer buzzer;
-extern DisplayManager display;
 
 Stopwatch::Stopwatch() {
   running = false;
@@ -38,6 +34,12 @@ void Stopwatch::update() {
 
 void Stopwatch::draw(DisplayManager& display) {
   display.drawText("Stopwatch", 30, 0);
+
+  if (running) {
+    sprite.drawWink(display, 90, 0);
+  } else {
+    sprite.drawIdle(display, 90, 0);
+  }
 
   unsigned long displayMillis = running ? (millis() - startMillis + elapsedMillis) : elapsedMillis;
   int sec = (displayMillis / 1000) % 60;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -23,11 +23,11 @@ void setup() {
   buzzer.begin();
 
   display.clear();
-  display.drawText("HappyTomato V1.0", 0, 5, 1);
-  display.drawText("Made with love <3", 0, 40, 1);
-  delay(1500);
+  display.drawText("Let's Focus!", 20, 0, 1);
+  sprite.drawCheer(display, 0, 0);
+  display.drawText("happytomato", 28, 56, 1);
   display.update();
-  delay(1000);
+  delay(1500);
 
   menu.begin();
 }

--- a/src/ui/Menu.cpp
+++ b/src/ui/Menu.cpp
@@ -1,9 +1,8 @@
 // Menu.cpp - Scrollable feature menu for HappyTomato
 
 #include "ui/Menu.h"
-#include "hardware/Buzzer.h"
+#include "globals.h"
 
-extern Buzzer buzzer;
 
 void Menu::begin() {
   currentSelection = 0;
@@ -29,6 +28,8 @@ void Menu::update(int scrollAmount) {
 }
 
 void Menu::draw(DisplayManager& display) {
+  sprite.drawIdle(display, 90, 0);
+
   const int lineHeight = 10;
   const int maxVisible = 5;
   int start = currentSelection - 2;


### PR DESCRIPTION
## Summary
- expose `TomatoSprite` in `globals.h`
- display sprite on startup splash
- show the sprite across Pomodoro, Garden, Stopwatch, Breathing, Power Nap, Settings and menu screens
- include `globals.h` everywhere instead of repeating externs

## Testing
- `pio run` *(fails: `command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_683fc3c317308323a52b1643e7d3a378